### PR TITLE
[setup] add upcoming node LTS version 10 to travis and appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ before_script:
 script:
   - npm test
 node_js:
+  - "10"
   - "8"
   - "6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
   matrix:
     - nodejs_version: 6
     - nodejs_version: 8
+    - nodejs_version: 10
 
 version: "{build}"
 build: off
@@ -14,8 +15,6 @@ matrix:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm --version
-  - npm -g install npm@3
   - set PATH=%APPDATA%\npm;%PATH%
   - npm install eslint eslint-plugin-import
   - npm install --ignore-scripts --force

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "private": false,
     "engines": {
-        "node": ">=4 <9",
+        "node": ">=4",
         "npm": ">=3 <6"
     },
     "repository": {


### PR DESCRIPTION
For upcoming node LTS version 10 we should change the engine configuration:
https://github.com/namics/eslint-config-namics/blob/master/package.json#L9

My proposition: 

```
"engines": {
    "node": ">=4",
    "npm": ">=3 <6"
},
```

What do you think?