### PR TITLE
fix(typescript): move typescript extensions import/resolver settings …

### DIFF
--- a/configurations/typescript-react.js
+++ b/configurations/typescript-react.js
@@ -1,38 +1,30 @@
 module.exports = {
-	'plugins': [
+	plugins: [
 		'@typescript-eslint',
 		'jsx-a11y',
 		'react',
 	],
-	'extends': [
+	extends: [
 		'./typescript.js',
 		'../rules/react.js',
 		'../rules/react-a11y.js',
 	].map(require.resolve),
-	'env': {
-		'browser': true,
-		'node': false,
-		'amd': false,
-		'mocha': true,
-		'jasmine': true,
-		'jest': true,
-		'jquery': true,
-		'serviceworker': true,
-		'worker': true,
+	env: {
+		browser: true,
+		node: false,
+		amd: false,
+		mocha: true,
+		jasmine: true,
+		jest: true,
+		jquery: true,
+		serviceworker: true,
+		worker: true,
 	},
-	'parserOptions': {
-		'ecmaVersion': 8,
-		'sourceType': 'module',
-		'ecmaFeatures': {
-			'jsx': true,
+	parserOptions: {
+		ecmaVersion: 8,
+		sourceType: 'module',
+		ecmaFeatures: {
+			jsx: true,
 		},
 	},
-	'settings': {
-		'import/resolver': {
-			'node': {
-				'extensions': ['.js', '.ts', '.jsx', '.tsx', '.json'],
-			},
-		},
-	},
-
 };

--- a/configurations/typescript.js
+++ b/configurations/typescript.js
@@ -1,12 +1,12 @@
 module.exports = {
 
-	parser: '@typescript-eslint/parser',
+	'parser': '@typescript-eslint/parser',
 
-	plugins: [
+	'plugins': [
 		'@typescript-eslint',
 	],
 
-	extends: [
+	'extends': [
 		'../rules/node-disable.js',
 		'../rules/best-practices.js',
 		'../rules/errors.js',
@@ -18,8 +18,15 @@ module.exports = {
 		'../rules/typescript.js',
 	].map(require.resolve),
 
-	parserOptions: {
-		project: './tsconfig.json',
+	'parserOptions': {
+		'project': './tsconfig.json',
 	},
 
+	'settings': {
+		'import/resolver': {
+			'node': {
+				'extensions': ['.js', '.ts', '.jsx', '.tsx', '.json'],
+			},
+		},
+	},
 };


### PR DESCRIPTION
fix(typescript): move typescript extensions import/resolver setting from typescript-react to typescript

Using typescript-browser or typescript-node will not allow to include several files (like .ts) this was already solved for typescript-react.
The merge will move this configuration to the general typescript configuration